### PR TITLE
johnn project update

### DIFF
--- a/students/johnn/project/dcd.py
+++ b/students/johnn/project/dcd.py
@@ -108,7 +108,7 @@ def admin(config):
         if command == "register":
             response = "registering {} {}".format(key, value)
             log.info(response)
-            admin.send_string(reponse)
+            admin.send_string(response)
             config.peers[key]=value
         if command == "get":
             log.info("getting {}".format(key))

--- a/students/johnn/project/dcd.py
+++ b/students/johnn/project/dcd.py
@@ -137,10 +137,11 @@ def admin(config):
                 message = talkback.recv_string()
                 log.debug("queried key/value {}, got value {} from remote server".format(topic, message))
                 config.pub_queue.put((topic, message))
-            log.debug("asking {} to connect back to me ({})".format(value, options.admin_interface))
-            talkback.send_string("('link', None, '{}')".format(options.admin_interface))
-            message = talkback.recv_string()
-            log.debug("got {}".format(message))
+            # disabled since this will cause an infinite loop
+            # log.debug("asking {} to connect back to me ({})".format(value, options.admin_interface))
+            # talkback.send_string("('link', None, '{}')".format(options.admin_interface))
+            # message = talkback.recv_string()
+            # log.debug("got {}".format(message))
 
 
 def pub(config):

--- a/students/johnn/project/dcd.py
+++ b/students/johnn/project/dcd.py
@@ -73,10 +73,12 @@ log.info("logging to {}".format(log_path))
 log.debug("screen log level {}".format(options.stream_log_level))
 
 def decode_command(message):
+    log.debug("admin received raw message '{}'".format(message))
     try:
         command, key, value = eval(message)
     except SyntaxError:
         command, key, value = (None, None, None)
+    log.debug("decoded message to cmd '{}', key '{}', value '{}'".format( command, key, value))
     return ( command, key, value )
 
 def blob(config):
@@ -88,12 +90,12 @@ def admin(config):
     admin.bind(options.admin_interface)
     log.info("admin bound on {}".format(options.admin_interface))
 
-    talkback = context.socket(zmq.REQ)
+    s2s_admin = context.socket(zmq.REQ)
 
     while True:
         command, key, value = decode_command(admin.recv_string())
         response = ""
-        log.info("received command {}, key {}, value {}".format(command, key, value))
+        log.info("received command '{}', key '{}', value '{}'".format(command, key, value))
         if command == "dump":
             log.debug("dump request, responding {}".format(blob(config)))
             log.info("dump request")
@@ -110,27 +112,74 @@ def admin(config):
             log.info(response)
             admin.send_string(response)
             config.peers[key]=value
+
+        if command == "sync":
+            """
+            cmd = sync, key = None, value = <server to sync to>
+            """
+            response = "ack sync to {}".format(value)
+            log.debug(response)
+            admin.send_string(response)
+            log.debug("opening connection to " + str(value))
+            s2s_admin.connect(value)
+            cmd = ("('dump', None, None)")
+            log.debug("sending command " + cmd )
+            s2s_admin.send_string(cmd)
+            message = s2s_admin.recv_string()
+            log.debug("got " + str(message) )
+            remote_ports, data, peers = eval(message)
+            # remote_admin, remote_pub = remote_ports
+            # config.peers[remote_admin] = remote_pub
+            # log.debug("remote_admin {}, remote_pub {}, data {}, peers {}".format(remote_admin, remote_pub, data, peers))
+            for topic in data:
+                log.debug("subscribing to topic {}".format(topic))
+                config.sub_queue.put(topic)
+                s2s_admin.send_string("('get', '{}', None)".format(topic))
+                message = s2s_admin.recv_string()
+                log.debug("queried key/value {}, got value {} from remote server".format(topic, message))
+                config.pub_queue.put((topic, message))
+            log.debug("asking {} to register my addresses".format(value))
+            cmd = "('register', '{}', '{}')".format(options.admin_interface, options.pub_interface)
+            log.debug("sending: " + cmd)
+            s2s_admin.send_string(cmd)
+            message = s2s_admin.recv_string()
+            # disabled since this will cause an infinite loop
+            # log.debug("asking {} to connect back to me ({})".format(value, options.admin_interface))
+            # s2s_admin.send_string("('link', None, '{}')".format(options.admin_interface))
+            # message = s2s_admin.recv_string()
+            log.debug("got {}".format(message))
+
         if command == "get":
-            log.info("getting {}".format(key))
-            try:
-                config.sub_queue.put(key)
-                value = config.get_value(key)
-                response = value
-                admin.send_string(response)
-            except KeyError:
-                config.sub_queue.put(key)
-                response = ""
-                admin.send_string(response)
+            """
+            cmd = get, key = <key to get>, value = None
+            """
+            log.debug("got cmd get")
+            response = get_value(config, key)
+            admin.send_string(response)
+            # log.info("getting {}".format(key))
+            # try:
+            #     config.sub_queue.put(key)
+            #     value = config.get_value(key)
+            #     response = value
+            #     admin.send_string(response)
+            # except KeyError:
+            #     config.sub_queue.put(key)
+            #     response = ""
+            #     admin.send_string(response)
+
         if command == "link":
+            """
+            cmd = link, key = None, value = <admin port of remote server to link to>
+            """
             response = "initiating a link request to remote admin port at {}".format(value)
             log.debug(response)
             admin.send_string(response)
             log.debug("opening connection to " + str(value))
-            talkback.connect(value)
+            s2s_admin.connect(value)
             cmd = ("('dump', None, None)")
             log.debug("sending command " + cmd )
-            talkback.send_string(cmd)  
-            message = talkback.recv_string()
+            s2s_admin.send_string(cmd)  
+            message = s2s_admin.recv_string()
             log.debug("got " + str(message) )
             remote_ports, data, peers = eval(message)
             remote_admin, remote_pub = remote_ports
@@ -139,62 +188,134 @@ def admin(config):
             for topic in data:
                 log.debug("subscribing to topic {}".format(topic))
                 config.sub_queue.put(topic)
-                talkback.send_string("('get', '{}', None)".format(topic))
-                message = talkback.recv_string()
+                s2s_admin.send_string("('get', '{}', None)".format(topic))
+                message = s2s_admin.recv_string()
                 log.debug("queried key/value {}, got value {} from remote server".format(topic, message))
                 config.pub_queue.put((topic, message))
             log.debug("asking {} to register my addresses".format(value))
             cmd = "('register', '{}', '{}')".format(options.admin_interface, options.pub_interface)
             log.debug("sending: " + cmd)
-            talkback.send_string(cmd)
-            message = talkback.recv_string()
+            s2s_admin.send_string(cmd)
+            message = s2s_admin.recv_string()
             # disabled since this will cause an infinite loop
             # log.debug("asking {} to connect back to me ({})".format(value, options.admin_interface))
-            # talkback.send_string("('link', None, '{}')".format(options.admin_interface))
-            # message = talkback.recv_string()
+            # s2s_admin.send_string("('link', None, '{}')".format(options.admin_interface))
+            # message = s2s_admin.recv_string()
             log.debug("got {}".format(message))
 
 
+def get_value(config, key):
+        """
+        given a key, get a value
+
+        cmd = get, key = <key to get>, value = None
+
+        check locally first, then query the remote servers.
+        return value or null
+        """
+        log.debug("in get_value")
+        value = ""
+        try:
+            # try getting the value locally
+            value = config.get_value(key)
+            log.info("get_value fetched value {}/{} locally".format(key, value))
+        except KeyError:
+            if config.peers:
+                log.debug("value not in local database, checking remote servers")
+                for server in config.peers:
+                    #log.debug("querying remote server {}".format(server))
+                    server_result = s2s_admin("get", key, "", server)
+                    log.debug("querying server {} for {}".format(server, key))
+                    if server_result:
+                        value = server_result
+                        log.info("got value {}/{} from server {}".format(key, value, server))
+                        # if we didn't find the value locally, but found it remotely, cache it
+                        # in our local database
+                        config.set_value(key, value)
+                        log.debug("saved {}/{} to local database".format(key, value))
+                        # subscribe to key to automatically get future updates
+                        config.sub_queue(key)
+                        log.debug("added {} to subcribe queue".format(key))
+                        # stop as soon as we get a match
+                        log.debug("terminating server search")
+                        break
+            log.debug("no remote servers, no matching entry")
+        return value
+
+
+def s2s_admin(cmd, key, value, remote_server):
+    """
+    send a command to remote server, return result
+    """
+
+    context = zmq.Context()
+    s2s_admin = context.socket(zmq.REQ)
+    message = ""
+    log.debug("opening s2s_admin connection to " + str(remote_server))
+    s2s_admin.connect(remote_server)
+    cmd = "({})".format(", ".join((cmd, key, value)))
+    log.info("sending s2s_admin command " + cmd)
+    s2s_admin.send_string(cmd)
+    message = s2s_admin.recv_string()
+    log.info("received '" + str(message) + "' from remote server" )
+    s2s_admin.disconnect(remote_server)
+    log.debug("disconnected s2s_admin connection to " + str(remote_server))
+    return message
+
+
 def pub(config):
+    """
+    publish values found on the pub_queue
+    """
     context = zmq.Context()
     pub = context.socket(zmq.PUB)
     pub.bind(options.pub_interface)
-    log.info("pub bound on " + str(options.pub_interface))
+    log.info("pub thread bound on " + str(options.pub_interface))
 
     while True:
         try:
             key, value = config.pub_queue.get()
             config.set_value(key, value)
             pub.send_string("{} {}".format(key, value))
-            log.info("published queue_entry {} {}".format(key, value))
+            log.info("published pub_queue entry {}/{}".format(key, value))
         except queue.Empty:
             continue
 
 
 def sub(config):
-    # Socket to talk to server
+    """
+    subscribe to values found on the sub_queue
+    """
     context = zmq.Context()
-    socket = context.socket(zmq.SUB)
-
+    sub = context.socket(zmq.SUB)
     log.info("sub thread working")
 
     while True:
         try:
+            # check the queue for an entry, subscribe to what you find
             key = config.sub_queue.get()
-            log.info("noticed sub queue_entry {}".format(key))
-            socket.setsockopt_string(zmq.SUBSCRIBE, key)
+            sub.setsockopt_string(zmq.SUBSCRIBE, key)
+            log.info("subscribed to sub_queue entry {}".format(key))
+
         except queue.Empty:
+            # queue empty, nothing to do
             continue
-        try:
-            value = config.link_queue.get()
-            log.info("noticed link queue_entry {}".format(value))
-            socket.connect(value)
-        except queue.Empty:
-            continue
-        string = socket.recv_string()
-        key, value = string.split(" ", 1)
+
+        # check for subscriptions
+        subscription = sub.recv_string()
+        key, value = subscription.split(" ", 1)
+        # save value to the local database
         config.set_value( key, value )
-        log.info("sub got {} {}".format(key, value))
+        log.info("saved subsription {}/{} to local database".format(key, value))
+
+
+        # try:
+        #     value = config.link_queue.get()
+        #     log.info("noticed link queue_entry {}".format(value))
+        #     socket.connect(value)
+        # except queue.Empty:
+        #     continue
+
 
 
 class Config():

--- a/students/johnn/project/dcd.py
+++ b/students/johnn/project/dcd.py
@@ -130,6 +130,14 @@ def admin(config):
             remote_ports, data, peers = eval(message)
             remote_admin, remote_pub = remote_ports
             log.debug("remote_admin {}, remote_pub {}, data {}, peers {}".format(remote_admin, remote_pub, data, peers))
+            for topic in data:
+                log.debug("subscribing to topic {}".format(topic))
+                config.sub_queue.put(topic)
+                talkback.send_string("('get', '{}', None)".format(topic))
+                message = talkback.recv_string()
+                log.debug("queried key/value {}, got value {} from remote server".format(topic, message))
+                config.pub_queue.put((topic, message))
+
 
 def pub(config):
     context = zmq.Context()

--- a/students/johnn/project/dcd.py
+++ b/students/johnn/project/dcd.py
@@ -137,6 +137,10 @@ def admin(config):
                 message = talkback.recv_string()
                 log.debug("queried key/value {}, got value {} from remote server".format(topic, message))
                 config.pub_queue.put((topic, message))
+            log.debug("asking {} to connect back to me ({})".format(value, options.admin_interface))
+            talkback.send_string("('link', None, '{}')".format(options.admin_interface))
+            message = talkback.recv_string()
+            log.debug("got {}".format(message))
 
 
 def pub(config):

--- a/students/johnn/project/dcd.py
+++ b/students/johnn/project/dcd.py
@@ -106,7 +106,9 @@ def admin(config):
             response = "ack"
             admin.send_string(response)
         if command == "register":
-            log.info("registering {} {}".format(key, value))
+            response = "registering {} {}".format(key, value)
+            log.info(response)
+            admin.send_string(reponse)
             config.peers[key]=value
         if command == "get":
             log.info("getting {}".format(key))

--- a/students/johnn/project/dcd.py
+++ b/students/johnn/project/dcd.py
@@ -105,6 +105,9 @@ def admin(config):
             config.sub_queue.put(key)
             response = "ack"
             admin.send_string(response)
+        if command == "register":
+            log.info("registering {} {}".format(key, value))
+            config.peers[key]=value
         if command == "get":
             log.info("getting {}".format(key))
             try:
@@ -138,11 +141,14 @@ def admin(config):
                 message = talkback.recv_string()
                 log.debug("queried key/value {}, got value {} from remote server".format(topic, message))
                 config.pub_queue.put((topic, message))
+            log.debug("asking {} to register my addresses")
+            talkback.send_string("('register', '{}', '{}'')".format(config.admin_interface, config.pub_interface))
+            message = talkback.recv_string()
             # disabled since this will cause an infinite loop
             # log.debug("asking {} to connect back to me ({})".format(value, options.admin_interface))
             # talkback.send_string("('link', None, '{}')".format(options.admin_interface))
             # message = talkback.recv_string()
-            # log.debug("got {}".format(message))
+            log.debug("got {}".format(message))
 
 
 def pub(config):

--- a/students/johnn/project/dcd.py
+++ b/students/johnn/project/dcd.py
@@ -129,6 +129,7 @@ def admin(config):
             log.debug("got " + str(message) )
             remote_ports, data, peers = eval(message)
             remote_admin, remote_pub = remote_ports
+            config.peers[remote_admin] = remote_pub
             log.debug("remote_admin {}, remote_pub {}, data {}, peers {}".format(remote_admin, remote_pub, data, peers))
             for topic in data:
                 log.debug("subscribing to topic {}".format(topic))

--- a/students/johnn/project/dcd.py
+++ b/students/johnn/project/dcd.py
@@ -143,8 +143,10 @@ def admin(config):
                 message = talkback.recv_string()
                 log.debug("queried key/value {}, got value {} from remote server".format(topic, message))
                 config.pub_queue.put((topic, message))
-            log.debug("asking {} to register my addresses")
-            talkback.send_string("('register', '{}', '{}'')".format(options.admin_interface, options.pub_interface))
+            log.debug("asking {} to register my addresses".format(value))
+            cmd = "('register', '{}', '{}'')".format(options.admin_interface, options.pub_interface)
+            log.debug("sending: " + cmd)
+            talkback.send_string(cmd)
             message = talkback.recv_string()
             # disabled since this will cause an infinite loop
             # log.debug("asking {} to connect back to me ({})".format(value, options.admin_interface))

--- a/students/johnn/project/dcd.py
+++ b/students/johnn/project/dcd.py
@@ -142,7 +142,7 @@ def admin(config):
                 log.debug("queried key/value {}, got value {} from remote server".format(topic, message))
                 config.pub_queue.put((topic, message))
             log.debug("asking {} to register my addresses")
-            talkback.send_string("('register', '{}', '{}'')".format(config.admin_interface, config.pub_interface))
+            talkback.send_string("('register', '{}', '{}'')".format(options.admin_interface, options.pub_interface))
             message = talkback.recv_string()
             # disabled since this will cause an infinite loop
             # log.debug("asking {} to connect back to me ({})".format(value, options.admin_interface))

--- a/students/johnn/project/dcd.py
+++ b/students/johnn/project/dcd.py
@@ -144,7 +144,7 @@ def admin(config):
                 log.debug("queried key/value {}, got value {} from remote server".format(topic, message))
                 config.pub_queue.put((topic, message))
             log.debug("asking {} to register my addresses".format(value))
-            cmd = "('register', '{}', '{}'')".format(options.admin_interface, options.pub_interface)
+            cmd = "('register', '{}', '{}')".format(options.admin_interface, options.pub_interface)
             log.debug("sending: " + cmd)
             talkback.send_string(cmd)
             message = talkback.recv_string()

--- a/students/johnn/project/dcd.py
+++ b/students/johnn/project/dcd.py
@@ -247,7 +247,8 @@ def s2s_admin(command, key, value, remote_server):
     """
     send a command to remote server, return result
     """
-
+    log.debug("s2s_admin called with cmd '{}', key '{}', value '{}', server '{}'".
+        format(command, key, value, remote_server))
     context = zmq.Context()
     s2s_admin = context.socket(zmq.REQ)
     message = ""
@@ -328,6 +329,7 @@ def sub_poller(config):
     subscribe to values found on the sub_queue
     """
     # stub
+    log.debug("sub_poller thread (barely) working")
     while True:
         time.sleep(5)
     # context = zmq.Context()


### PR DESCRIPTION
This is still pretty rough, and it still doesn't work quite the way I want it to, but it's a slightly better.  It's known that a bunch of things don't work, and even if they did the model isn't particular good and has a lot of problematic edge cases.

The dcd.py process is intended to run on multiple servers, with pub/sub relationships and the ability to be given commands through an admin interface.

A normal startup looks like:

```
johnn@johnn-lnx:~/uwpython/IntroPython-2017/students/johnn/project$ ./dcd.py -d
2018-03-12 22:41:09,106 INFO dcd:MainThread process dcd, config.pid 14918 on 192.168.1.209 starting
2018-03-12 22:41:09,107 INFO dcd:MainThread logging to log/dcd-14918.log
2018-03-12 22:41:09,107 DEBUG dcd:MainThread screen log level 10
2018-03-12 22:41:09,107 DEBUG dcd:MainThread admin_thread is Thread-1
2018-03-12 22:41:09,108 DEBUG dcd:MainThread pub_thread is Thread-2
2018-03-12 22:41:09,108 DEBUG dcd:MainThread sub_subscriber_thread is Thread-3
2018-03-12 22:41:09,108 DEBUG dcd:MainThread sub_poller_thread is Thread-4
2018-03-12 22:41:09,109 DEBUG dcd:Thread-1 ADMIN INTERFACE tcp://*:5561
2018-03-12 22:41:09,110 INFO dcd:Thread-2 pub thread bound on tcp://*:5556
2018-03-12 22:41:09,110 INFO dcd:Thread-1 admin bound on tcp://*:5561
2018-03-12 22:41:09,111 INFO dcd:Thread-3 sub_subscriber thread working
2018-03-12 22:41:09,111 DEBUG dcd:Thread-4 sub_poller thread (barely) working
```

Each different workload has it's own thread and they communicate between threads using the queue.Queue() mechanism.

In these examples, we have one server running on IP 192.168.1.209 and one on IP 192.168.1.65.

The command line interface can be used to "put" or "get" values, and can be directed to any running server.  

In this example, we ask for the value dog from the 209 server:
```
johnn@johnn-lnx:~/uwpython/IntroPython-2017/students/johnn/project$ ./dcli --server "tcp://192.168.1.209:5561" --get --key dog
please enter a command
2018-03-12 22:44:57,024 INFO dcli 6198 sent ('get', 'dog', '') to tcp://192.168.1.209:5561
2018-03-12 22:44:57,025 INFO dcli 6198 received:
johnn@johnn-lnx:~/uwpython/IntroPython-2017/students/johnn/project$
```

We got a null response back, and on the server, we see:

```
2018-03-12 22:44:56,986 DEBUG dcd:Thread-1 received command 'get', key 'dog', value ''
2018-03-12 22:44:56,986 DEBUG dcd:Thread-1 no remote servers, no matching entry
```

So, it returned null because it had no entry.  

The same interface can be used to set values, like:

```
johnn@johnn-lnx:~/uwpython/IntroPython-2017/students/johnn/project$ ./dcli --server "tcp://192.168.1.209:5561" --put --key dog --value black
please enter a command
2018-03-12 22:47:22,480 INFO dcli 6201 sent ('put', 'dog', 'black') to tcp://192.168.1.209:5561
2018-03-12 22:47:22,482 INFO dcli 6201 received: dog/black has been published
johnn@johnn-lnx:~/uwpython/IntroPython-2017/students/johnn/project$
```

Here we see an acknowledgement that the value pair was received.   Note the message we print on the cli side was send from the server -- there are no canned responses in dcli, it simply prints what it was sent from the server it contacted.

On the server, we see the following:

```
2018-03-12 22:47:22,449 DEBUG dcd:Thread-1 received command 'put', key 'dog', value 'black'
2018-03-12 22:47:22,450 INFO dcd:Thread-2 published pub_queue entry dog/black
2018-03-12 22:47:22,450 INFO dcd:Thread-3 subscribed to sub_queue entry 'dog'
2018-03-12 22:47:22,450 DEBUG dcd:Thread-3 checking for subscriptions
2018-03-12 22:47:23,454 DEBUG dcd:Thread-3 no subscrition activity, logged 'Resource temporarily unavailable'
```

Here, the admin thread (Thread-1) got the command, saved it to the local database, then put the key ("dog") on both the publish and subscribe queues and we see the related worker threads (Thread-2 and Thread-3) pick up the entries and publish and subscribe.  The "no subscrition[sic]" message because there was nothing on the subscription channel to pick up.

Now, let's link the two servers together.  We issue a command telling 209 to link to 65 using it's admin interface:

```
johnn@johnn-lnx:~/uwpython/IntroPython-2017/students/johnn/project$ ./dcli --server "tcp://192.168.1.209:5561" --link "tcp://192.168.1.65:5561"
please enter a command
2018-03-12 22:52:25,826 INFO dcli 6206 sent ('link', '', 'tcp://192.168.1.65:5561') to tcp://192.168.1.209:5561
2018-03-12 22:52:25,836 INFO dcli 6206 received: got tcp://192.168.1.209:5561/tcp://192.168.1.209:5556 has been registered
johnn@johnn-lnx:~/uwpython/IntroPython-2017/students/johnn/project$
```

On the 209 server, we see the following:

```
2018-03-12 22:58:26,584 DEBUG dcd:Thread-1 received command 'link', key '', value 'tcp://192.168.1.65:5561'
2018-03-12 22:58:26,584 DEBUG dcd:Thread-1 initiating a link request to remote admin port at tcp://192.168.1.65:5561
2018-03-12 22:58:26,584 DEBUG dcd:Thread-1 s2s_admin called with cmd 'dump', key '', value '', server 'tcp://192.168.1.65:5561'
2018-03-12 22:58:26,585 DEBUG dcd:Thread-1 opening s2s_admin connection to tcp://192.168.1.65:5561
2018-03-12 22:58:26,585 INFO dcd:Thread-1 sending s2s_admin command ('dump', '', '')
2018-03-12 22:58:26,587 INFO dcd:Thread-1 received '(('tcp://192.168.1.65:5561', 'tcp://192.168.1.65:5556'), {'car': 'blue'}, {'tcp://192.168.1.209:5561': 'tcp://192.168.1.209:5556'})' from remote server
2018-03-12 22:58:26,587 DEBUG dcd:Thread-1 disconnected s2s_admin connection to tcp://192.168.1.65:5561
2018-03-12 22:58:26,588 DEBUG dcd:Thread-1 saving remote server ('tcp://192.168.1.65:5561', 'tcp://192.168.1.65:5556') in database
2018-03-12 22:58:26,588 DEBUG dcd:Thread-1 s2s_admin called with cmd 'register', key 'tcp://192.168.1.209:5561', value 'tcp://192.168.1.209:5556', server 'tcp://192.168.1.65:5561'
2018-03-12 22:58:26,588 INFO dcd:Thread-3 subscribed to sub_queue entry 'car'
2018-03-12 22:58:26,588 DEBUG dcd:Thread-1 opening s2s_admin connection to tcp://192.168.1.65:5561
2018-03-12 22:58:26,589 DEBUG dcd:Thread-3 checking for subscriptions
2018-03-12 22:58:26,589 INFO dcd:Thread-1 sending s2s_admin command ('register', 'tcp://192.168.1.209:5561', 'tcp://192.168.1.209:5556')
2018-03-12 22:58:26,591 INFO dcd:Thread-1 received 'tcp://192.168.1.209:5561/tcp://192.168.1.209:5556 has been registered' from remote server
2018-03-12 22:58:26,591 DEBUG dcd:Thread-1 disconnected s2s_admin connection to tcp://192.168.1.65:5561
2018-03-12 22:58:27,591 DEBUG dcd:Thread-3 no subscrition activity, logged 'Resource temporarily unavailable'
2018-03-12 22:58:27,591 DEBUG dcd:Thread-3 sub_subscriber connecting to tcp://192.168.1.65:5556
```

What is happening here is the admin thread (Thread-1) got the command and remote address to connect to.  

Then, the 209 server sends a dump command to the 65 server using that remote address.  The dump command sends back a tuple containing the remote servers' admin and publish interfaces, a dictionary containing all it's data (key/value pairs) and a dictionary containing all the servers it is connected to.

The 209 server saves the remote addresses in it's local peer database.  It then issues a "register" command to the remote server so the remote server has the 209 server in its peer database.

Next, we walk through the data from the remote server and put each data key in the subscribe queue (in this case there is a single entry, "car") so we can be notified if the data is modified on the remote server.

Now that we are linked, we have a bit different behavior with queries.

When we ask a server that has the value in its database, we can see the server just returns it from the local database:

```
johnn@johnn-lnx:~/uwpython/IntroPython-2017/students/johnn/project$ ./dcli --server "tcp://192.168.1.209:5561" --get --key dog
please enter a command
2018-03-12 23:06:22,649 INFO dcli 6244 sent ('get', 'dog', '') to tcp://192.168.1.209:5561
2018-03-12 23:06:22,652 INFO dcli 6244 received: black
johnn@johnn-lnx:~/uwpython/IntroPython-2017/students/johnn/project$
```

```
2018-03-12 23:06:22,621 DEBUG dcd:Thread-1 received command 'get', key 'dog', value ''
2018-03-12 23:06:22,621 INFO dcd:Thread-1 get_value fetched value dog/black locally
```

But if we ask a server that does not have the value locally, we see it returns the value anyway:

```
johnn@johnn-lnx:~/uwpython/IntroPython-2017/students/johnn/project$ ./dcli --server "tcp://192.168.1.65:5561" --get --key dog
please enter a command
2018-03-12 23:08:03,844 INFO dcli 6256 sent ('get', 'dog', '') to tcp://192.168.1.65:5561
2018-03-12 23:08:03,851 INFO dcli 6256 received: black
johnn@johnn-lnx:~/uwpython/IntroPython-2017/students/johnn/project$
```

On the queried server, we see:

```
2018-03-12 23:08:03,845 DEBUG dcd:Thread-1 received command 'get', key 'dog', value ''
2018-03-12 23:08:03,845 DEBUG dcd:Thread-1 value not in local database, checking remote servers
2018-03-12 23:08:03,845 DEBUG dcd:Thread-1 s2s_admin called with cmd 'get', key 'dog', value '', server 'tcp://192.168.1.209:5561'
2018-03-12 23:08:03,846 DEBUG dcd:Thread-1 opening s2s_admin connection to tcp://192.168.1.209:5561
2018-03-12 23:08:03,846 INFO dcd:Thread-1 sending s2s_admin command ('get', 'dog', '')
2018-03-12 23:08:03,848 INFO dcd:Thread-1 received 'black' from remote server
2018-03-12 23:08:03,849 DEBUG dcd:Thread-1 disconnected s2s_admin connection to tcp://192.168.1.209:5561
2018-03-12 23:08:03,849 INFO dcd:Thread-1 got value dog/black from server tcp://192.168.1.209:5561
2018-03-12 23:08:03,850 DEBUG dcd:Thread-1 saved dog/black to local database
2018-03-12 23:08:03,850 DEBUG dcd:Thread-1 added dog to subcribe queue
2018-03-12 23:08:03,850 INFO dcd:Thread-3 subscribed to sub_queue entry 'dog'
2018-03-12 23:08:03,850 DEBUG dcd:Thread-1 terminating server search
2018-03-12 23:08:03,851 DEBUG dcd:Thread-3 checking for subscriptions
2018-03-12 23:08:04,853 DEBUG dcd:Thread-3 no subscrition activity, logged 'Resource temporarily unavailable'
2018-03-12 23:08:04,854 DEBUG dcd:Thread-3 sub_subscriber connecting to tcp://192.168.1.209:5556
```

The server checked it's local database, found that it didn't have the entry, then proceeded to see if any of the servers it was linked to have the data by sending them "get" requests.  The 209 server returned the data and the queried server saves it to it's local database, then subscribes/publishes the value.

On the 209 server, we see it simply found the data and returned it to the remote server:

```
2018-03-12 23:08:03,816 DEBUG dcd:Thread-1 received command 'get', key 'dog', value ''
2018-03-12 23:08:03,816 INFO dcd:Thread-1 get_value fetched value dog/black locally
```
